### PR TITLE
Update appSetting name to reflect what code is expecting

### DIFF
--- a/source/Database.Demo/App.config
+++ b/source/Database.Demo/App.config
@@ -2,7 +2,7 @@
 <configuration>
   <appSettings>
     <add key="DatabaseName" value=""/>
-    <add key="ServerName" value=""/>   
+    <add key="DatabaseServer" value=""/>   
   </appSettings>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>


### PR DESCRIPTION
The code was always defaulting to sqlexpress because the config file used a different appSetting name than it was looking for.
