### PR TITLE
Allow quoted path with spaces in it.

### DIFF
--- a/source/AliaSQL.Console/Program.cs
+++ b/source/AliaSQL.Console/Program.cs
@@ -26,7 +26,7 @@ namespace AliaSQL.Console
             var action = requestedDatabaseAction;
             string server = args[1];
             string database = args[2];
-            string scriptDirectory = args[3];
+            string scriptDirectory = ConditionScriptPath(args[3]);
             
             if (args.Length == 4)
             {
@@ -74,6 +74,15 @@ namespace AliaSQL.Console
 
             if (Debugger.IsAttached)
                 System.Console.ReadLine();
+        }
+
+        private static string ConditionScriptPath(string initialPath)
+        {
+            if (initialPath.EndsWith("\""))
+                initialPath = initialPath.Remove(initialPath.Length - 1, 1);
+            if(!initialPath.EndsWith("\\"))
+                initialPath += "\\";
+            return initialPath;
         }
     }
 }


### PR DESCRIPTION
I started a project using the KickStarter in my C:\Users\boliver\documents\Visual Studio 2012\projects directory and had an issue where the space in the path was causing an invalid path. I change my local Program.cs to put quotes around the script path, but aliasql.exe left the trailing quote on. This removes the trailing quote and ensure there is a trailing backslash on the script path.