### PR TITLE
Fix DatabaseDropper Exception on attempting to drop database which doesn't exist

### DIFF
--- a/source/AliaSQL.Core/AliaSQL.Core.csproj
+++ b/source/AliaSQL.Core/AliaSQL.Core.csproj
@@ -61,6 +61,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exceptions\ServerConnectionFailedException.cs" />
     <Compile Include="Model\ConnectionSettings.cs" />
     <Compile Include="Model\TaskAttributes.cs" />
     <Compile Include="Services\Impl\DatabaseBaseliner.cs" />

--- a/source/AliaSQL.Core/Exceptions/ServerConnectionFailedException.cs
+++ b/source/AliaSQL.Core/Exceptions/ServerConnectionFailedException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace AliaSQL.Core.Exceptions
+{
+    [Serializable]
+    public class ServerConnectionFailedException : Exception
+    {
+        public ServerConnectionFailedException() { }
+
+        public ServerConnectionFailedException(string message) : base(message) { }
+
+        public ServerConnectionFailedException(string message, Exception inner) : base(message, inner) { }
+
+        protected ServerConnectionFailedException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context)
+            : base(info, context) { }
+    }
+}

--- a/source/AliaSQL.Core/Services/Impl/DatabaseDropper.cs
+++ b/source/AliaSQL.Core/Services/Impl/DatabaseDropper.cs
@@ -24,6 +24,11 @@ namespace AliaSQL.Core.Services.Impl
 
         public void Execute(TaskAttributes taskAttributes, ITaskObserver taskObserver)
         {
+            if (!_queryExecutor.CheckDatabaseExists(taskAttributes.ConnectionSettings))
+            {
+                return;
+            }
+
             var version = _queryExecutor.ReadFirstColumnAsStringArray(taskAttributes.ConnectionSettings, "select @@version")[0];
              taskObserver.Log("Running against: " + version);
 

--- a/source/AliaSQL.IntegrationTests/AliaSQL.IntegrationTests.csproj
+++ b/source/AliaSQL.IntegrationTests/AliaSQL.IntegrationTests.csproj
@@ -52,6 +52,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="RebuildOfMissingDatabaseShouldRunTester.cs" />
+    <Content Include="Scripts\RebuildOfMissingDatabaseShouldRun\Update\TestScript.sql" />
     <Content Include="Scripts\ChangedEverytimeScriptShouldRun\Everytime\TestScript.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -78,6 +80,8 @@
     <Folder Include="Scripts\NewEverytimeScript\Update\" />
     <Folder Include="Scripts\OldEverytimeScriptShouldNotRun\Create\" />
     <Folder Include="Scripts\OldEverytimeScriptShouldNotRun\Update\" />
+    <Folder Include="Scripts\RebuildOfMissingDatabaseShouldRun\Create\" />
+    <Folder Include="Scripts\RebuildOfMissingDatabaseShouldRun\Everytime\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AliaSQL.Console\AliaSQL.Console.csproj">

--- a/source/AliaSQL.IntegrationTests/AliaSQL.IntegrationTests.csproj
+++ b/source/AliaSQL.IntegrationTests/AliaSQL.IntegrationTests.csproj
@@ -53,7 +53,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="RebuildOfMissingDatabaseShouldRunTester.cs" />
-    <Content Include="Scripts\RebuildOfMissingDatabaseShouldRun\Update\TestScript.sql" />
+    <Compile Include="Utils\DatabaseIntegrationHelpers.cs" />
+    <Content Include="Scripts\RebuildOfMissingDatabaseShouldRun\Update\TestScript.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Scripts\ChangedEverytimeScriptShouldRun\Everytime\TestScript.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/source/AliaSQL.IntegrationTests/NewEverytimeScriptTester.cs
+++ b/source/AliaSQL.IntegrationTests/NewEverytimeScriptTester.cs
@@ -1,11 +1,12 @@
-﻿using System;
-using System.Data.SqlClient;
-using System.IO;
-using AliaSQL.Console;
+﻿using AliaSQL.Console;
 using AliaSQL.Core.Model;
 using AliaSQL.Core.Services.Impl;
+using AliaSQL.IntegrationTests.Utils;
 using NUnit.Framework;
 using Should;
+using System;
+using System.Data.SqlClient;
+using System.IO;
 
 namespace AliaSQL.IntegrationTests.NewEverytimeScript
 {
@@ -25,10 +26,9 @@ namespace AliaSQL.IntegrationTests.NewEverytimeScript
             //act
             bool success = new ConsoleAliaSQL().UpdateDatabase(settings, scriptsDirectory, RequestedDatabaseAction.Update);
 
-
             //assert
             int records = 0;
-            AssertUsdAppliedDatabaseScriptTable(settings, reader =>
+            DatabaseIntegrationHelpers.AssertUsdAppliedDatabaseScriptTable(settings, reader =>
             {
                 while (reader.Read())
                 {
@@ -41,26 +41,5 @@ namespace AliaSQL.IntegrationTests.NewEverytimeScript
             success.ShouldEqual(true);
             records.ShouldEqual(1);
         }
-
-        private void AssertUsdAppliedDatabaseScriptTable(ConnectionSettings settings, Action<SqlDataReader> assertAction)
-        {
-            string connectionString = new ConnectionStringGenerator().GetConnectionString(settings, true);
-
-            using (var connection = new SqlConnection(connectionString))
-            {
-                connection.Open();
-                using (var command = new SqlCommand())
-                {
-                    command.Connection = connection;
-                    command.CommandText =
-                        "SELECT  [ScriptFile],[DateApplied],[Version],[hash] FROM [dbo].[usd_AppliedDatabaseScript]";
-                    using (SqlDataReader reader = command.ExecuteReader())
-                    {
-                        assertAction(reader);
-                    }
-                }
-            }
-        }
-
     }
 }

--- a/source/AliaSQL.IntegrationTests/RebuildOfMissingDatabaseShouldRunTester.cs
+++ b/source/AliaSQL.IntegrationTests/RebuildOfMissingDatabaseShouldRunTester.cs
@@ -1,0 +1,41 @@
+﻿using AliaSQL.Console;
+using AliaSQL.Core.Model;
+using AliaSQL.Core.Services.Impl;
+using NUnit.Framework;
+using Should;
+using System.IO;
+
+namespace AliaSQL.IntegrationTests
+{
+    [TestFixture]
+    public class RebuildOfMissingDatabaseShouldRunTester
+    {
+        [Test]
+        public void Rebuild_Missing_Database_Generates_Database()
+        {
+            //arrange
+            string scriptsDirectory = Path.Combine("Scripts", 
+                this.GetType().Name.Replace("Tester", string.Empty));
+
+            var settings = new ConnectionSettings(".\\sqlexpress", "aliasqltest", true, null, null);
+            
+            var aliaConsole = new ConsoleAliaSQL();
+
+            //act
+            //database should not exist
+            DatabaseDoesNotExist(settings).ShouldBeTrue();
+
+            //assert
+            aliaConsole.UpdateDatabase(settings, scriptsDirectory, RequestedDatabaseAction.Rebuild).ShouldBeTrue();
+        }
+
+        private bool DatabaseDoesNotExist(ConnectionSettings settings)
+        {
+            var queryExecutor = new QueryExecutor();
+
+            string sql = string.Format("select count(1) AS Databases from master..sysdatabases where name = '{0}';", settings.Database);
+
+            return queryExecutor.ExecuteScalarInteger(settings, sql) == 0;
+        }
+    }
+}

--- a/source/AliaSQL.IntegrationTests/Scripts/RebuildOfMissingDatabaseShouldRun/Update/TestScript.sql
+++ b/source/AliaSQL.IntegrationTests/Scripts/RebuildOfMissingDatabaseShouldRun/Update/TestScript.sql
@@ -1,0 +1,6 @@
+﻿CREATE TABLE Test
+(
+    Id INT NOT NULL,
+    Description NVARCHAR(25) NOT NULL
+);
+GO

--- a/source/AliaSQL.IntegrationTests/Utils/DatabaseIntegrationHelpers.cs
+++ b/source/AliaSQL.IntegrationTests/Utils/DatabaseIntegrationHelpers.cs
@@ -1,0 +1,31 @@
+﻿using AliaSQL.Core.Model;
+using AliaSQL.Core.Services;
+using AliaSQL.Core.Services.Impl;
+using System;
+using System.Data.SqlClient;
+
+namespace AliaSQL.IntegrationTests.Utils
+{
+    internal class DatabaseIntegrationHelpers
+    {
+        public static void AssertUsdAppliedDatabaseScriptTable(ConnectionSettings settings, Action<SqlDataReader> assertAction)
+        {
+            string connectionString = new ConnectionStringGenerator().GetConnectionString(settings, true);
+
+            using (var connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+                using (var command = new SqlCommand())
+                {
+                    command.Connection = connection;
+                    command.CommandText =
+                        "SELECT  [ScriptFile],[DateApplied],[Version],[hash] FROM [dbo].[usd_AppliedDatabaseScript]";
+                    using (SqlDataReader reader = command.ExecuteReader())
+                    {
+                        assertAction(reader);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/source/AliaSQL.UnitTests/DatabaseDropperTester.cs
+++ b/source/AliaSQL.UnitTests/DatabaseDropperTester.cs
@@ -21,7 +21,9 @@ namespace AliaSQL.UnitTests
             var connectionDropper = mocks.StrictMock<IDatabaseConnectionDropper>();
             var taskObserver = mocks.StrictMock<ITaskObserver>();
             var queryExecutor = mocks.StrictMock<IQueryExecutor>();
-            
+
+            Set_CheckDatabaseExists_to_return_true(queryExecutor, settings);
+
 			using (mocks.Record())
 			{
 				Expect.Call(() => taskObserver.Log("Running against: SQL Server"));
@@ -51,6 +53,8 @@ namespace AliaSQL.UnitTests
             var taskObserver = mocks.StrictMock<ITaskObserver>();
             var queryExecutor = mocks.StrictMock<IQueryExecutor>();
 
+            Set_CheckDatabaseExists_to_return_true(queryExecutor, settings);
+
             using (mocks.Record())
             {
                 Expect.Call(() => taskObserver.Log("Running against: SQL Azure"));
@@ -79,6 +83,8 @@ namespace AliaSQL.UnitTests
             var taskObserver = mocks.StrictMock<ITaskObserver>();
             var queryExecutor = mocks.StrictMock<IQueryExecutor>();
 
+            Set_CheckDatabaseExists_to_return_true(queryExecutor, settings);
+
 			using (mocks.Record())
 			{
                 Expect.Call(() => taskObserver.Log("Running against: SQL Server"));
@@ -98,5 +104,10 @@ namespace AliaSQL.UnitTests
 
 			mocks.VerifyAll();
 		}
+
+        private void Set_CheckDatabaseExists_to_return_true(IQueryExecutor queryExecutor, ConnectionSettings settings)
+        {
+            queryExecutor.Stub(x => x.CheckDatabaseExists(settings)).Return(true);
+        }
 	}
 }

--- a/source/AliaSQL.UnitTests/DatabaseDropperTester.cs
+++ b/source/AliaSQL.UnitTests/DatabaseDropperTester.cs
@@ -8,44 +8,14 @@ using System.Linq;
 
 namespace AliaSQL.UnitTests
 {
-	[TestFixture]
-	public class DatabaseDropperTester
-	{
-		[Test]
-		public void Drops_database()
-		{
-			var settings = new ConnectionSettings("server", "db", true, null, null);
-            var taskAttributes = new TaskAttributes(settings, null);
-
-			var mocks = new MockRepository();
-            var connectionDropper = mocks.StrictMock<IDatabaseConnectionDropper>();
-            var taskObserver = mocks.StrictMock<ITaskObserver>();
-            var queryExecutor = mocks.StrictMock<IQueryExecutor>();
-
-            Set_CheckDatabaseExists_to_return_true(queryExecutor, settings);
-
-			using (mocks.Record())
-			{
-				Expect.Call(() => taskObserver.Log("Running against: SQL Server"));
-                Expect.Call(queryExecutor.ReadFirstColumnAsStringArray(settings, "select @@version")).Return(new string[] { "SQL Server"});
-                connectionDropper.Drop(settings, taskObserver);
-                queryExecutor.ExecuteNonQuery(settings, "ALTER DATABASE [db] SET SINGLE_USER WITH ROLLBACK IMMEDIATE drop database [db]");
-                Expect.Call(() => taskObserver.Log("Dropping database: db\n"));
-			}
-
-			using (mocks.Playback())
-			{
-				IDatabaseActionExecutor dropper = new DatabaseDropper(connectionDropper, queryExecutor);
-				dropper.Execute(taskAttributes, taskObserver);
-			}
-
-			mocks.VerifyAll();
-		}
+    [TestFixture]
+    public class DatabaseDropperTester
+    {
+        private ConnectionSettings settings = new ConnectionSettings("server", "db", true, null, null);
 
         [Test]
-        public void Drops_Azure_database_without_dropping_connections()
+        public void Drops_database()
         {
-            var settings = new ConnectionSettings("server", "db", true, null, null);
             var taskAttributes = new TaskAttributes(settings, null);
 
             var mocks = new MockRepository();
@@ -53,7 +23,59 @@ namespace AliaSQL.UnitTests
             var taskObserver = mocks.StrictMock<ITaskObserver>();
             var queryExecutor = mocks.StrictMock<IQueryExecutor>();
 
-            Set_CheckDatabaseExists_to_return_true(queryExecutor, settings);
+            SetCheckDatabaseExistsValue(queryExecutor, settings, true);
+
+            using (mocks.Record())
+            {
+                Expect.Call(() => taskObserver.Log("Running against: SQL Server"));
+                Expect.Call(queryExecutor.ReadFirstColumnAsStringArray(settings, "select @@version")).Return(new string[] { "SQL Server" });
+                connectionDropper.Drop(settings, taskObserver);
+                queryExecutor.ExecuteNonQuery(settings, "ALTER DATABASE [db] SET SINGLE_USER WITH ROLLBACK IMMEDIATE drop database [db]");
+                Expect.Call(() => taskObserver.Log("Dropping database: db\n"));
+            }
+
+            using (mocks.Playback())
+            {
+                IDatabaseActionExecutor dropper = new DatabaseDropper(connectionDropper, queryExecutor);
+                dropper.Execute(taskAttributes, taskObserver);
+            }
+
+            mocks.VerifyAll();
+        }
+
+        [Test]
+        public void Does_not_drop_missing_database()
+        {
+            var taskAttributes = new TaskAttributes(settings, null);
+
+            var mocks = new MockRepository();
+
+            var connectionDropper = mocks.StrictMock<IDatabaseConnectionDropper>();
+            var taskObserver = mocks.StrictMock<ITaskObserver>();
+            var queryExecutor = mocks.StrictMock<IQueryExecutor>();
+
+            SetCheckDatabaseExistsValue(queryExecutor, settings, false);
+
+            queryExecutor.Replay();
+
+            IDatabaseActionExecutor dropper = new DatabaseDropper(connectionDropper, queryExecutor);
+
+            dropper.Execute(taskAttributes, taskObserver);
+
+            queryExecutor.AssertWasCalled(qe => qe.CheckDatabaseExists(settings));
+        }
+
+        [Test]
+        public void Drops_Azure_database_without_dropping_connections()
+        {
+            var taskAttributes = new TaskAttributes(settings, null);
+
+            var mocks = new MockRepository();
+            var connectionDropper = mocks.StrictMock<IDatabaseConnectionDropper>();
+            var taskObserver = mocks.StrictMock<ITaskObserver>();
+            var queryExecutor = mocks.StrictMock<IQueryExecutor>();
+
+            SetCheckDatabaseExistsValue(queryExecutor, settings, true);
 
             using (mocks.Record())
             {
@@ -72,42 +94,40 @@ namespace AliaSQL.UnitTests
             mocks.VerifyAll();
         }
 
-		[Test]
-		public void Should_not_fail_if_datebase_does_not_exist()
-		{
-			var settings = new ConnectionSettings("server", "db", true, null, null);
+        [Test]
+        public void Should_not_fail_if_datebase_does_not_exist()
+        {
             var taskAttributes = new TaskAttributes(settings, null);
 
-			var mocks = new MockRepository();
-			var connectionDropper = mocks.DynamicMock<IDatabaseConnectionDropper>();
+            var mocks = new MockRepository();
+            var connectionDropper = mocks.DynamicMock<IDatabaseConnectionDropper>();
             var taskObserver = mocks.StrictMock<ITaskObserver>();
             var queryExecutor = mocks.StrictMock<IQueryExecutor>();
 
-            Set_CheckDatabaseExists_to_return_true(queryExecutor, settings);
+            SetCheckDatabaseExistsValue(queryExecutor, settings, true);
 
-			using (mocks.Record())
-			{
+            using (mocks.Record())
+            {
                 Expect.Call(() => taskObserver.Log("Running against: SQL Server"));
                 Expect.Call(queryExecutor.ReadFirstColumnAsStringArray(settings, "select @@version")).Return(new string[] { "SQL Server" });
                 Expect.Call(() => taskObserver.Log("Dropping database: db\n"));
                 Expect.Call(() => queryExecutor.ExecuteNonQuery(settings, "ALTER DATABASE [db] SET SINGLE_USER WITH ROLLBACK IMMEDIATE drop database [db]"))
-					.Throw(new Exception("foo message"));
-				Expect.Call(() => taskObserver.Log("Database 'db' could not be dropped."));
+                    .Throw(new Exception("foo message"));
+                Expect.Call(() => taskObserver.Log("Database 'db' could not be dropped."));
+            }
 
-			}
-
-			using (mocks.Playback())
-			{
-				IDatabaseActionExecutor dropper = new DatabaseDropper(connectionDropper, queryExecutor);
+            using (mocks.Playback())
+            {
+                IDatabaseActionExecutor dropper = new DatabaseDropper(connectionDropper, queryExecutor);
                 dropper.Execute(taskAttributes, taskObserver);
-			}
+            }
 
-			mocks.VerifyAll();
-		}
-
-        private void Set_CheckDatabaseExists_to_return_true(IQueryExecutor queryExecutor, ConnectionSettings settings)
-        {
-            queryExecutor.Stub(x => x.CheckDatabaseExists(settings)).Return(true);
+            mocks.VerifyAll();
         }
-	}
+
+        private void SetCheckDatabaseExistsValue(IQueryExecutor queryExecutor, ConnectionSettings settings, bool result)
+        {
+            queryExecutor.Stub(x => x.CheckDatabaseExists(settings)).Return(result);
+        }
+    }
 }


### PR DESCRIPTION
I've added a check for the database existing on the server and also an exception which is thrown when the server itself does not exist. To do this I reworked the existing ```CheckDatabaseExists``` method on ```QueryExecutor```.

This check is now called as the first method in Execute and returns out of this method if the database isn't found.

I've added test coverage for the change and refactored existing tests to account for the change.