### PR TITLE
Added feature RunAlways

### DIFF
--- a/source/AliaSQL.Core/Services/IChangeScriptExecutor.cs
+++ b/source/AliaSQL.Core/Services/IChangeScriptExecutor.cs
@@ -9,6 +9,7 @@ namespace AliaSQL.Core.Services
 		void Execute(string fullFilename, ConnectionSettings settings, ITaskObserver taskObserver, bool logOnly = false);
 
         void ExecuteIfChanged(string fullFilename, ConnectionSettings settings, ITaskObserver taskObserver, bool logOnly = false);
-       
-	}
+
+	    void ExecuteAlways(string fullFilename, ConnectionSettings settings, ITaskObserver taskObserver, bool logOnly = false);
+    }
 }

--- a/source/AliaSQL.Core/Services/IScriptFolderExecutor.cs
+++ b/source/AliaSQL.Core/Services/IScriptFolderExecutor.cs
@@ -12,5 +12,6 @@ namespace AliaSQL.Core.Services
          
         void ExecuteTestDataScriptsInFolder(TaskAttributes taskAttributes, string scriptDirectory, ITaskObserver taskObserver);
 
+	    void ExecuteRunAlwaysScriptsInFolder(TaskAttributes taskAttributes, string scriptDirectory, ITaskObserver taskObserver);
 	}
 }

--- a/source/AliaSQL.Core/Services/Impl/ChangeScriptExecutor.cs
+++ b/source/AliaSQL.Core/Services/Impl/ChangeScriptExecutor.cs
@@ -86,6 +86,26 @@ namespace AliaSQL.Core.Services.Impl
             }
         }
 
+        public void ExecuteAlways(string fullFilename, ConnectionSettings settings, ITaskObserver taskObserver, bool logOnly = false)
+        {
+            string scriptFilename = getFilename(fullFilename);
+            var scriptFileMD5 = GetFileMD5Hash(fullFilename);
+
+            if (!logOnly)
+            {
+                string sql = _fileSystem.ReadTextFile(fullFilename);
+
+                taskObserver.Log(string.Format("Executing: {0}{1}", getLastFolderName(fullFilename), scriptFilename));
+                _executor.ExecuteNonQuery(settings, sql, true);
+            }
+            else
+            {
+                taskObserver.Log(string.Format("Executing: {0}{1} in log only mode", getLastFolderName(fullFilename), scriptFilename));
+            }
+
+            _executionTracker.MarkScriptAsExecuted(settings, scriptFilename, taskObserver, scriptFileMD5);
+        }
+
         public static string GetFileMD5Hash(string fullFilename)
         {
             string scriptFileMD5;
@@ -111,6 +131,7 @@ namespace AliaSQL.Core.Services.Impl
             if (lastfolder.ToLower() == "create") return string.Empty;
             if (lastfolder.ToLower() == "update") return string.Empty;
             if (lastfolder.ToLower() == "everytime") return string.Empty;
+            if (lastfolder.ToLower() == "runalways") return string.Empty;
             return lastfolder + "/";
         }
 

--- a/source/AliaSQL.Core/Services/Impl/DatabaseUpdater.cs
+++ b/source/AliaSQL.Core/Services/Impl/DatabaseUpdater.cs
@@ -34,7 +34,10 @@ namespace AliaSQL.Core.Services.Impl
 
             taskObserver.Log(string.Format("Run scripts in Everytime folder."));
             _folderExecutor.ExecuteChangedScriptsInFolder(taskAttributes, "Everytime", taskObserver);
-		}
+
+            taskObserver.Log(string.Format("Run scripts in RunAlways folder."));
+            _folderExecutor.ExecuteRunAlwaysScriptsInFolder(taskAttributes, "RunAlways", taskObserver);
+        }
 
 	}
 }

--- a/source/AliaSQL.Core/Services/Impl/ScriptFolderExecutor.cs
+++ b/source/AliaSQL.Core/Services/Impl/ScriptFolderExecutor.cs
@@ -52,6 +52,18 @@ namespace AliaSQL.Core.Services.Impl
             _versioner.VersionDatabase(taskAttributes.ConnectionSettings, taskObserver);
         }
 
+        public void ExecuteRunAlwaysScriptsInFolder(TaskAttributes taskAttributes, string scriptDirectory, ITaskObserver taskObserver)
+        {
+            var sqlFilenames = _fileLocator.GetSqlFilenames(taskAttributes.ScriptDirectory, scriptDirectory);
+
+            foreach (string sqlFilename in sqlFilenames)
+            {
+                _scriptExecutor.ExecuteAlways(sqlFilename, taskAttributes.ConnectionSettings, taskObserver, taskAttributes.LogOnly);
+            }
+
+            _versioner.VersionDatabase(taskAttributes.ConnectionSettings, taskObserver);
+        }
+
         public void ExecuteTestDataScriptsInFolder(TaskAttributes taskAttributes, string scriptDirectory, ITaskObserver taskObserver)
         {
             _schemaInitializer.EnsureTestDataSchemaCreated(taskAttributes.ConnectionSettings);

--- a/source/AliaSQL.IntegrationTests/AliaSQL.IntegrationTests.csproj
+++ b/source/AliaSQL.IntegrationTests/AliaSQL.IntegrationTests.csproj
@@ -55,6 +55,12 @@
     <Content Include="Scripts\ChangedEverytimeScriptShouldRun\Everytime\TestScript.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Scripts\ChangedRunAlwaysScriptShouldRun\RunAlways\TestScript.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Scripts\NewRunAlwaysScriptShouldRun\RunAlways\TestScript.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Scripts\OldEverytimeScriptShouldNotRun\Everytime\TestScript.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -62,10 +68,16 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Compile Include="ChangedEverytimeScriptShouldRunTester.cs" />
+    <Compile Include="ChangedRunAlwaysScriptShouldRunTester.cs" />
+    <Compile Include="NewRunAlwaysScriptShouldRunTester.cs" />
     <Compile Include="OldEverytimeScriptShouldNotRunTester.cs" />
     <Compile Include="NewEverytimeScriptTester.cs" />
+    <Compile Include="OldRunAlwaysScriptShouldRunTester.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Content Include="Scripts\OldRunAlwaysScriptShouldRun\RunAlways\TestScript.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -74,10 +86,19 @@
   <ItemGroup>
     <Folder Include="Scripts\ChangedEverytimeScriptShouldRun\Create\" />
     <Folder Include="Scripts\ChangedEverytimeScriptShouldRun\Update\" />
+    <Folder Include="Scripts\ChangedRunAlwaysScriptShouldRun\Create\" />
+    <Folder Include="Scripts\ChangedRunAlwaysScriptShouldRun\Everytime\" />
+    <Folder Include="Scripts\ChangedRunAlwaysScriptShouldRun\Update\" />
     <Folder Include="Scripts\NewEverytimeScript\Create\" />
     <Folder Include="Scripts\NewEverytimeScript\Update\" />
+    <Folder Include="Scripts\NewRunAlwaysScriptShouldRun\Create\" />
+    <Folder Include="Scripts\NewRunAlwaysScriptShouldRun\Everytime\" />
+    <Folder Include="Scripts\NewRunAlwaysScriptShouldRun\Update\" />
     <Folder Include="Scripts\OldEverytimeScriptShouldNotRun\Create\" />
     <Folder Include="Scripts\OldEverytimeScriptShouldNotRun\Update\" />
+    <Folder Include="Scripts\OldRunAlwaysScriptShouldRun\Create\" />
+    <Folder Include="Scripts\OldRunAlwaysScriptShouldRun\Everytime\" />
+    <Folder Include="Scripts\OldRunAlwaysScriptShouldRun\Update\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AliaSQL.Console\AliaSQL.Console.csproj">

--- a/source/AliaSQL.IntegrationTests/ChangedRunAlwaysScriptShouldRunTester.cs
+++ b/source/AliaSQL.IntegrationTests/ChangedRunAlwaysScriptShouldRunTester.cs
@@ -1,0 +1,42 @@
+﻿using System.IO;
+using AliaSQL.Console;
+using AliaSQL.Core.Model;
+using AliaSQL.Core.Services.Impl;
+using NUnit.Framework;
+using Should;
+
+namespace AliaSQL.IntegrationTests.ChangedRunAlwaysScriptShouldRun
+{
+    [TestFixture]
+    public class ChangedRunAlwaysScriptShouldRunTester
+    {
+        [Test]
+        public void Update_Database_Runs_Changed_RunAlways_Script()
+        {
+
+            //arrange
+            string scriptsDirectory = Path.Combine("Scripts", GetType().Name.Replace("Tester", ""));
+
+            var settings = new ConnectionSettings(".\\sqlexpress", "aliasqltest", true, null, null);
+            new ConsoleAliaSQL().UpdateDatabase(settings, scriptsDirectory, RequestedDatabaseAction.Drop);
+
+            //act
+            //run once 
+            new ConsoleAliaSQL().UpdateDatabase(settings, scriptsDirectory, RequestedDatabaseAction.Update).ShouldBeTrue();
+            new QueryExecutor().ExecuteScalarInteger(settings, "select 1 from dbo.sysobjects where name = 'TestTable' and type='U'").ShouldEqual(1);
+
+            //change contents of script
+            File.WriteAllText(Path.Combine(scriptsDirectory, "RunAlways", "TestScript.sql"), "CREATE TABLE [dbo].[TestTable2]([Id] [int] IDENTITY(1,1) NOT NULL, [FullName] [nvarchar](50) NULL)");
+
+            new ConsoleAliaSQL().UpdateDatabase(settings, scriptsDirectory, RequestedDatabaseAction.Update).ShouldBeTrue();
+
+            //assert
+            new QueryExecutor().ExecuteScalarInteger(settings, "select 1 from dbo.sysobjects where name = 'TestTable2' and type='U'").ShouldEqual(1);
+
+            //change contents of script back in case you run again without rebuilding
+            File.WriteAllText(Path.Combine(scriptsDirectory, "RunAlways", "TestScript.sql"), "CREATE TABLE [dbo].[TestTable]([Id] [int] IDENTITY(1,1) NOT NULL, [FullName] [nvarchar](50) NULL)");
+
+        }
+
+    }
+}

--- a/source/AliaSQL.IntegrationTests/NewRunAlwaysScriptShouldRunTester.cs
+++ b/source/AliaSQL.IntegrationTests/NewRunAlwaysScriptShouldRunTester.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Data.SqlClient;
+using System.IO;
+using AliaSQL.Console;
+using AliaSQL.Core.Model;
+using AliaSQL.Core.Services.Impl;
+using NUnit.Framework;
+using Should;
+
+namespace AliaSQL.IntegrationTests.NewRunAlwaysScriptShouldRun
+{
+    [TestFixture]
+    public class NewRunAlwaysScriptShouldRunTester
+    {
+        [Test]
+        public void Update_Database_Runs_New_RunAlways_Script()
+        {
+            //arrange
+            string scriptsDirectory =  Path.Combine("Scripts",GetType().Name.Replace("Tester", ""));
+
+            string scriptFileMd5 = ChangeScriptExecutor.GetFileMD5Hash(Path.Combine(scriptsDirectory,"RunAlways", "TestScript.sql"));
+            var settings = new ConnectionSettings(".\\sqlexpress", "aliasqltest", true, null, null);
+            new ConsoleAliaSQL().UpdateDatabase(settings, scriptsDirectory, RequestedDatabaseAction.Drop);
+
+            //act
+            bool success = new ConsoleAliaSQL().UpdateDatabase(settings, scriptsDirectory, RequestedDatabaseAction.Update);
+
+
+            //assert
+            int records = 0;
+            AssertUsdAppliedDatabaseScriptTable(settings, reader =>
+            {
+                while (reader.Read())
+                {
+                    records++;
+                    reader["ScriptFile"].ShouldEqual("TestScript.sql");
+                    reader["hash"].ShouldEqual(scriptFileMd5);
+                }
+            });
+
+            success.ShouldEqual(true);
+            records.ShouldEqual(1);
+        }
+
+        private void AssertUsdAppliedDatabaseScriptTable(ConnectionSettings settings, Action<SqlDataReader> assertAction)
+        {
+            string connectionString = new ConnectionStringGenerator().GetConnectionString(settings, true);
+
+            using (var connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+                using (var command = new SqlCommand())
+                {
+                    command.Connection = connection;
+                    command.CommandText =
+                        "SELECT  [ScriptFile],[DateApplied],[Version],[hash] FROM [dbo].[usd_AppliedDatabaseScript]";
+                    using (SqlDataReader reader = command.ExecuteReader())
+                    {
+                        assertAction(reader);
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/source/AliaSQL.IntegrationTests/OldRunAlwaysScriptShouldRunTester.cs
+++ b/source/AliaSQL.IntegrationTests/OldRunAlwaysScriptShouldRunTester.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Data.SqlClient;
+using System.IO;
+using AliaSQL.Console;
+using AliaSQL.Core.Model;
+using AliaSQL.Core.Services.Impl;
+using NUnit.Framework;
+using Should;
+
+namespace AliaSQL.IntegrationTests.OldRunAlwaysScriptShouldRun
+{
+    [TestFixture]
+    public class OldRunAlwaysScriptShouldRunTester
+    {
+        [Test]
+        public void Update_Database_ShouldRun_Old_RunAlways_Script()
+        {
+            //arrange
+            string scriptsDirectory = Path.Combine("Scripts", GetType().Name.Replace("Tester", ""));
+
+            var settings = new ConnectionSettings(".\\sqlexpress", "aliasqltest", true, null, null);
+            new ConsoleAliaSQL().UpdateDatabase(settings, scriptsDirectory, RequestedDatabaseAction.Drop);
+
+            //act
+            //run once 
+            new ConsoleAliaSQL().UpdateDatabase(settings, scriptsDirectory, RequestedDatabaseAction.Update).ShouldBeTrue();
+            new QueryExecutor().ExecuteScalarInteger(settings, "select 1 from dbo.sysobjects where name = 'TestTable' and type='U'").ShouldEqual(1);
+            var dateApplied = DateTime.MinValue;
+            QueryUsdAppliedDatabaseScriptTable(settings, reader =>
+            {
+                while (reader.Read())
+                {
+                    reader["ScriptFile"].ShouldEqual("TestScript.sql");
+                    dateApplied = (DateTime)reader["DateApplied"];
+                }
+            });
+            dateApplied.ShouldBeGreaterThan(DateTime.MinValue);
+
+            //delete TestTable to ensure script doesn't run again
+            new QueryExecutor().ExecuteNonQuery(settings, "drop table TestTable", true);
+
+            //run again
+            bool success = new ConsoleAliaSQL().UpdateDatabase(settings, scriptsDirectory, RequestedDatabaseAction.Update);
+
+            //assert
+            new QueryExecutor().ExecuteScalarInteger(settings, "select 1 from dbo.sysobjects where name = 'TestTable' and type='U'").ShouldEqual(1);
+
+            DateTime dateAppliedUpdated = DateTime.MinValue; ;
+            int records = 0;
+            QueryUsdAppliedDatabaseScriptTable(settings, reader =>
+            {
+                while (reader.Read())
+                {
+                    records++;
+                    reader["ScriptFile"].ShouldEqual("TestScript.sql");
+                    dateAppliedUpdated = (DateTime) reader["DateApplied"];
+                }
+               
+            });
+
+            success.ShouldBeTrue();
+            records.ShouldEqual(1);
+            dateAppliedUpdated.ShouldBeGreaterThan(dateApplied);
+        }
+
+
+        private void QueryUsdAppliedDatabaseScriptTable(ConnectionSettings settings, Action<SqlDataReader> action)
+        {
+            string connectionString = new ConnectionStringGenerator().GetConnectionString(settings, true);
+
+            using (var connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+                using (var command = new SqlCommand())
+                {
+                    command.Connection = connection;
+                    command.CommandText =
+                        "SELECT  [ScriptFile],[DateApplied],[Version],[hash] FROM [dbo].[usd_AppliedDatabaseScript]";
+                    using (SqlDataReader reader = command.ExecuteReader())
+                    {
+                        action(reader);
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/source/AliaSQL.IntegrationTests/Scripts/ChangedRunAlwaysScriptShouldRun/RunAlways/TestScript.sql
+++ b/source/AliaSQL.IntegrationTests/Scripts/ChangedRunAlwaysScriptShouldRun/RunAlways/TestScript.sql
@@ -1,0 +1,1 @@
+﻿CREATE TABLE [dbo].[TestTable]([Id] [int] IDENTITY(1,1) NOT NULL, [FullName] [nvarchar](50) NULL)

--- a/source/AliaSQL.IntegrationTests/Scripts/NewRunAlwaysScriptShouldRun/RunAlways/TestScript.sql
+++ b/source/AliaSQL.IntegrationTests/Scripts/NewRunAlwaysScriptShouldRun/RunAlways/TestScript.sql
@@ -1,0 +1,1 @@
+﻿select @@version

--- a/source/AliaSQL.IntegrationTests/Scripts/OldRunAlwaysScriptShouldRun/RunAlways/TestScript.sql
+++ b/source/AliaSQL.IntegrationTests/Scripts/OldRunAlwaysScriptShouldRun/RunAlways/TestScript.sql
@@ -1,0 +1,3 @@
+﻿CREATE TABLE [dbo].[TestTable](
+	[Id] [int] IDENTITY(1,1) NOT NULL,
+	[FullName] [nvarchar](50) NULL)

--- a/source/AliaSQL.UnitTests/DatabaseUpdaterTester.cs
+++ b/source/AliaSQL.UnitTests/DatabaseUpdaterTester.cs
@@ -29,7 +29,10 @@ namespace AliaSQL.UnitTests
 
                 taskObserver.Log(string.Format("Run scripts in Everytime folder."));
                 scriptfolderexecutor.ExecuteChangedScriptsInFolder(taskAttributes, "Everytime", taskObserver);
-			}
+
+                taskObserver.Log(string.Format("Run scripts in RunAlways folder."));
+                scriptfolderexecutor.ExecuteRunAlwaysScriptsInFolder(taskAttributes, "RunAlways", taskObserver);
+            }
 
 			using (mocks.Playback())
 			{


### PR DESCRIPTION
Scripts in RunAlways folder will be executed always, not only when there are new/changed files like in Everytime folder.
It's a useful feature for scenarios when there are scripts that have to be run after every update (e.g. maintenance and integrity check scripts)