### PR TITLE
Read the BOM and use it to set encoding when processing files

### DIFF
--- a/source/AliaSQL.Core/FileSystem.cs
+++ b/source/AliaSQL.Core/FileSystem.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-
+using System.Text;
 
 namespace AliaSQL.Core
 {
@@ -72,10 +72,37 @@ namespace AliaSQL.Core
         {
             var stream = _streamFactory.ConstructReadFileStream(filename);
 
-            using (var reader = new StreamReader(stream))
+            Encoding encoding = GetEncoding(filename);
+            using (var reader = new StreamReader(stream, encoding))
             {
                 return reader.ReadToEnd();
             }
+        }
+
+        /// <summary>
+        /// Determines a text file's encoding by analyzing its byte order mark (BOM)
+        /// Defaults to ASCII when detection of the text file's endianness fails.
+        /// Function originally from http://stackoverflow.com/questions/3825390/effective-way-to-find-any-files-encoding
+        /// </summary>
+        /// <param name="filename">The text file to analyze.</param>
+        /// <returns>The detected encoding.</returns>
+        private static Encoding GetEncoding(string filename)
+        {
+            // Read the BOM
+            var bom = new byte[4];
+            using (var file = new FileStream(filename, FileMode.Open, FileAccess.Read))
+            {
+                file.Read(bom, 0, 4);
+            }
+
+            // Analyze the BOM
+            if (bom[0] == 0x2b && bom[1] == 0x2f && bom[2] == 0x76) return Encoding.UTF7;
+            if (bom[0] == 0xef && bom[1] == 0xbb && bom[2] == 0xbf) return Encoding.UTF8;
+            if (bom[0] == 0xff && bom[1] == 0xfe) return Encoding.Unicode; //UTF-16LE
+            if (bom[0] == 0xfe && bom[1] == 0xff) return Encoding.BigEndianUnicode; //UTF-16BE
+            if (bom[0] == 0 && bom[1] == 0 && bom[2] == 0xfe && bom[3] == 0xff) return Encoding.UTF32;
+
+            return Encoding.ASCII;
         }
 
         public StreamReader ReadFileIntoStreamReader(string filename)

--- a/source/AliaSQL.Core/ResourceFileLocator.cs
+++ b/source/AliaSQL.Core/ResourceFileLocator.cs
@@ -12,7 +12,7 @@ namespace AliaSQL.Core
         {
             using (Stream stream = getStream(assembly, resourceName))
             {
-                using (StreamReader reader = new StreamReader(stream, Encoding.Default))
+                using (StreamReader reader = new StreamReader(stream, Encoding.UTF8))
                 {
                     string contents = reader.ReadToEnd();
                     return contents;


### PR DESCRIPTION
AliaSQL was having encoding problems when processing files with Spanish characters even though the BOM was set to UTF8. This was fixed by reading the BOM for the files and use the detected encoding as input to the StreamReader(...).

Tested locally by executing AliaSQL with files containing Spanish characters, which were read into a web UI and displayed correctly. It has been verified that the solution builds but I have not executed all the tests in the solution.