### PR TITLE
Add transactional support check for test data scripts

### DIFF
--- a/source/AliaSQL.Core/Services/IQueryExecutor.cs
+++ b/source/AliaSQL.Core/Services/IQueryExecutor.cs
@@ -13,6 +13,6 @@ namespace AliaSQL.Core.Services
 	    List<string> GetExecutedScripts(ConnectionSettings settings);
         List<string> GetExecutedTestDataScripts(ConnectionSettings settings);
 	    int DatabaseVersion(ConnectionSettings settings);
-
+	    bool ScriptSupportsTransactions(string sql);
 	}
 }

--- a/source/AliaSQL.Core/Services/Impl/ChangeScriptExecutor.cs
+++ b/source/AliaSQL.Core/Services/Impl/ChangeScriptExecutor.cs
@@ -38,7 +38,7 @@ namespace AliaSQL.Core.Services.Impl
                 if (!logOnly)
                 {
                     string sql = _fileSystem.ReadTextFile(fullFilename);
-                    if (!ScriptSupportsTransactions(sql))
+                    if (!_executor.ScriptSupportsTransactions(sql))
                     {
                         taskObserver.Log(string.Format("Executing: {0}{1}", getLastFolderName(fullFilename),scriptFilename));
                         _executor.ExecuteNonQuery(settings, sql, true);
@@ -133,37 +133,6 @@ namespace AliaSQL.Core.Services.Impl
             if (lastfolder.ToLower() == "everytime") return string.Empty;
             if (lastfolder.ToLower() == "runalways") return string.Empty;
             return lastfolder + "/";
-        }
-
-
-        /// <summary>
-        /// Some commands are not allowed inside transactions
-        /// http://msdn.microsoft.com/en-us/library/ms191544.aspx
-        /// </summary>
-        private bool ScriptSupportsTransactions(string sql)
-        {
-            if (sql.IndexOf("ALTER DATABASE", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-            if (sql.IndexOf("ALTER FULLTEXT CATALOG ", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-            if (sql.IndexOf("ALTER FULLTEXT INDEX ", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-            if (sql.IndexOf("BACKUP ", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-            if (sql.IndexOf("CREATE DATABASE", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-            if (sql.IndexOf("CREATE FULLTEXT CATALOG ", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-            if (sql.IndexOf("CREATE FULLTEXT INDEX", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-            if (sql.IndexOf("DROP DATABASE", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-            if (sql.IndexOf("DROP FULLTEXT CATALOG", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-            if (sql.IndexOf("DROP FULLTEXT INDEX", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-            if (sql.IndexOf("RECONFIGURE", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-            if (sql.IndexOf("RESTORE ", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-            //UPDATE STATISTICS can be used inside an explicit transaction. However, UPDATE STATISTICS commits independently of the enclosing transaction and cannot be rolled back.
-
-            //Many system stored procedures can't run in a transaction such as sp_fulltext_database
-            //More can be added here as they are discovered
-            if (sql.IndexOf("sp_fulltext_database", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-
-            //manual override of transactions
-            if (sql.IndexOf("--NOTRANSACTION", StringComparison.OrdinalIgnoreCase) >= 0) return false;
-
-            return true;
         }
     }
 }

--- a/source/AliaSQL.Core/Services/Impl/QueryExecutor.cs
+++ b/source/AliaSQL.Core/Services/Impl/QueryExecutor.cs
@@ -250,5 +250,34 @@ namespace AliaSQL.Core.Services.Impl
             return version;
         }
 
+        /// <summary>
+        /// Some commands are not allowed inside transactions
+        /// http://msdn.microsoft.com/en-us/library/ms191544.aspx
+        /// </summary>
+        public bool ScriptSupportsTransactions(string sql)
+        {
+            if (sql.IndexOf("ALTER DATABASE", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+            if (sql.IndexOf("ALTER FULLTEXT CATALOG ", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+            if (sql.IndexOf("ALTER FULLTEXT INDEX ", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+            if (sql.IndexOf("BACKUP ", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+            if (sql.IndexOf("CREATE DATABASE", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+            if (sql.IndexOf("CREATE FULLTEXT CATALOG ", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+            if (sql.IndexOf("CREATE FULLTEXT INDEX", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+            if (sql.IndexOf("DROP DATABASE", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+            if (sql.IndexOf("DROP FULLTEXT CATALOG", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+            if (sql.IndexOf("DROP FULLTEXT INDEX", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+            if (sql.IndexOf("RECONFIGURE", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+            if (sql.IndexOf("RESTORE ", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+            //UPDATE STATISTICS can be used inside an explicit transaction. However, UPDATE STATISTICS commits independently of the enclosing transaction and cannot be rolled back.
+
+            //Many system stored procedures can't run in a transaction such as sp_fulltext_database
+            //More can be added here as they are discovered
+            if (sql.IndexOf("sp_fulltext_database", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+
+            //manual override of transactions
+            if (sql.IndexOf("--NOTRANSACTION", StringComparison.OrdinalIgnoreCase) >= 0) return false;
+
+            return true;
+        }
     }
 }

--- a/source/AliaSQL.Core/Services/Impl/TestDataScriptExecutor.cs
+++ b/source/AliaSQL.Core/Services/Impl/TestDataScriptExecutor.cs
@@ -34,10 +34,17 @@ namespace AliaSQL.Core.Services.Impl
 			}
 			else
 			{
-				taskObserver.Log(string.Format("Executing: {0}", scriptFilename));
 				string sql = _fileSystem.ReadTextFile(fullFilename);
-				_executor.ExecuteNonQueryTransactional(settings, sql);
-                _executionTracker.MarkTestDataScriptAsExecuted(settings, scriptFilename, taskObserver);
+                if (!_executor.ScriptSupportsTransactions(sql))
+                {
+                    taskObserver.Log(string.Format("Executing: {0}", scriptFilename));
+                    _executor.ExecuteNonQuery(settings, sql, true);
+                }
+                else
+                {
+                    taskObserver.Log(string.Format("Executing: {0} in a transaction", scriptFilename));
+                    _executor.ExecuteNonQueryTransactional(settings, sql);
+                }
 			}
 		}
 

--- a/source/AliaSQL.UnitTests/ChangeScriptExecutorTester.cs
+++ b/source/AliaSQL.UnitTests/ChangeScriptExecutorTester.cs
@@ -68,6 +68,7 @@ namespace AliaSQL.UnitTests
 			Expect.Call(executionTracker.ScriptAlreadyExecuted(settings, "01_Test.sql")).Return(false);
 			taskObserver.Log("Executing: 01_Test.sql in a transaction");
 			Expect.Call(fileSystem.ReadTextFile(scriptFile)).Return(fileContents);
+            Expect.Call(queryExecutor.ScriptSupportsTransactions(fileContents)).Return(true);
 			queryExecutor.ExecuteNonQueryTransactional(settings, fileContents);
 			executionTracker.MarkScriptAsExecuted(settings, "01_Test.sql", taskObserver);
 
@@ -96,6 +97,7 @@ namespace AliaSQL.UnitTests
             Expect.Call(executionTracker.ScriptAlreadyExecuted(settings, "01_Test.sql")).Return(false);
             taskObserver.Log("Executing: 01_Test.sql");
             Expect.Call(fileSystem.ReadTextFile(scriptFile)).Return(fileContents);
+            Expect.Call(queryExecutor.ScriptSupportsTransactions(fileContents)).Return(false);
             queryExecutor.ExecuteNonQuery(settings, fileContents, true);
             executionTracker.MarkScriptAsExecuted(settings, "01_Test.sql", taskObserver);
 


### PR DESCRIPTION
We needed the same transaction checking for our test data scripts. This moves the transaction support check to the Query Executor so that it can be shared between test data and change script executors.