### PR TITLE
allow transaction to look for timeout setting in app.config

### DIFF
--- a/source/AliaSQL.Core/AliaSQL.Core.csproj
+++ b/source/AliaSQL.Core/AliaSQL.Core.csproj
@@ -58,6 +58,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
@@ -69,7 +70,10 @@
     <Compile Include="Model\ConnectionSettings.cs" />
     <Compile Include="Model\TaskAttributes.cs" />
     <Compile Include="RequestedDatabaseAction.cs" />
+    <Compile Include="Services\Impl\ApplicationSettings.cs" />
     <Compile Include="Services\Impl\DatabaseBaseliner.cs" />
+    <Compile Include="Services\IApplicationSettings.cs" />
+    <Compile Include="Services\Impl\TransactionProvider.cs" />
     <Compile Include="Services\ITestDataScriptExecutor.cs" />
     <Compile Include="Services\IChangeScriptExecutor.cs" />
     <Compile Include="Services\IConnectionStringGenerator.cs" />

--- a/source/AliaSQL.Core/Services/IApplicationSettings.cs
+++ b/source/AliaSQL.Core/Services/IApplicationSettings.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace AliaSQL.Core.Services
+{
+    internal interface IApplicationSettings
+    {
+        TimeSpan? Timeout();
+    }
+}

--- a/source/AliaSQL.Core/Services/Impl/ApplicationSettings.cs
+++ b/source/AliaSQL.Core/Services/Impl/ApplicationSettings.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Configuration;
+
+namespace AliaSQL.Core.Services.Impl
+{
+    internal class ApplicationSettings : IApplicationSettings
+    {
+        public TimeSpan? Timeout()
+        {
+            var timeoutValue = ConfigurationManager.AppSettings["timeout"];
+
+            if (string.IsNullOrEmpty(timeoutValue))
+            {
+                return null;
+            }
+
+            if (!TimeSpan.TryParse(timeoutValue, out var time))
+            {
+                return null;
+            }
+
+            return time;
+        }
+    }
+}

--- a/source/AliaSQL.Core/Services/Impl/ApplicationSettings.cs
+++ b/source/AliaSQL.Core/Services/Impl/ApplicationSettings.cs
@@ -7,7 +7,7 @@ namespace AliaSQL.Core.Services.Impl
     {
         public TimeSpan? Timeout()
         {
-            var timeoutValue = ConfigurationManager.AppSettings["timeout"];
+            var timeoutValue = ConfigurationManager.AppSettings["aliasql.transaction.timeout"];
 
             if (string.IsNullOrEmpty(timeoutValue))
             {

--- a/source/AliaSQL.Core/Services/Impl/QueryExecutor.cs
+++ b/source/AliaSQL.Core/Services/Impl/QueryExecutor.cs
@@ -72,7 +72,7 @@ namespace AliaSQL.Core.Services.Impl
         public void ExecuteNonQueryTransactional(ConnectionSettings settings, string sql)
         {
             //do all this in a single transaction
-            using (var scope = new TransactionScope())
+            using (var scope = new TransactionProvider().CreateTransactionScope())
             {
                 string connectionString = _connectionStringGenerator.GetConnectionString(settings, true);
                 using (var connection = new SqlConnection(connectionString))

--- a/source/AliaSQL.Core/Services/Impl/TransactionProvider.cs
+++ b/source/AliaSQL.Core/Services/Impl/TransactionProvider.cs
@@ -1,0 +1,34 @@
+﻿using System.Reflection;
+using System.Transactions;
+
+namespace AliaSQL.Core.Services.Impl
+{
+    internal class TransactionProvider
+    {
+        private readonly IApplicationSettings _applicationSettings;
+
+        public TransactionProvider()
+        {
+            _applicationSettings = new ApplicationSettings();
+        }
+        
+        private void SetTransactionManagerField(string fieldName, object value)
+        {
+            typeof(TransactionManager).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, value);
+        }
+
+        public TransactionScope CreateTransactionScope()
+        {
+            var timeout = _applicationSettings.Timeout();
+
+            if (timeout == null)
+            {
+                return new TransactionScope();
+            }
+
+            SetTransactionManagerField("_cachedMaxTimeout", true);
+            SetTransactionManagerField("_maximumTimeout", timeout.GetValueOrDefault());
+            return new TransactionScope(TransactionScopeOption.RequiresNew, timeout.GetValueOrDefault());
+        }
+    }
+}


### PR DESCRIPTION
if not present, revert to previous/default behaviour.

This is so long running sql scripts don't time out.

couldn't get the build batch scripts to complete, so the exe hasn't been rebuilt as part of this commit